### PR TITLE
Node styling fix

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -25,7 +25,7 @@ export var DEFAULT_CONFIG = {
             gridSize: 10
         },
         node: {
-            fill: '#293538',
+            fill: '#2c393c',
             fillSecondary: '#364346',
             stroke: '#293538',
             strokeSelected: '#F60',

--- a/src/graph-view-node.js
+++ b/src/graph-view-node.js
@@ -34,13 +34,13 @@ class GraphViewNode {
         var portHeight = 0;
         var attributeHeight = 0;
         if (nodeSchema.inPorts) {
-            portHeight = (nodeSchema.inPorts.length * 25) + 12;
+            portHeight = (nodeSchema.inPorts.length * 25) + 10;
         }
         if (nodeSchema.outPorts) {
-            var outHeight = (nodeSchema.outPorts.length * 25) + 12;
+            var outHeight = (nodeSchema.outPorts.length * 25) + 10;
             if (outHeight > portHeight) portHeight = outHeight;
         }
-        if (nodeSchema.attributes) {
+        if (nodeSchema.attributes && nodeSchema.attributes.length > 0) {
             attributeHeight = nodeSchema.attributes.length * 32 + 10;
         }
         var rectSize = { x: 226, y: rectHeight + portHeight + attributeHeight };
@@ -62,10 +62,17 @@ class GraphViewNode {
                 },
                 labelBackground: {
                     fill: this.getSchemaValue('fill'),
-                    refX: 1,
-                    refY: 1,
+                    refX: 2,
+                    refY: 2,
+                    width: rectSize.x - 4,
+                    height: rectHeight - 4
+                },
+                labelSeparator: {
+                    fill: this.getSchemaValue('stroke'),
                     width: rectSize.x - 2,
-                    height: rectHeight - 2
+                    height: this.getSchemaValue('inPorts') || this.getSchemaValue('outPorts') ? 2 : 0,
+                    refX: 1,
+                    refY: rectHeight - 1
                 },
                 inBackground: {
                     fill: this.getSchemaValue('fillSecondary'),

--- a/src/joint-shape-node.js
+++ b/src/joint-shape-node.js
@@ -17,6 +17,9 @@ const jointShapeElement = () => joint.shapes.standard.Rectangle.extend({
             selector: 'labelBackground'
         }, {
             tagName: 'rect',
+            selector: 'labelSeparator'
+        }, {
+            tagName: 'rect',
             selector: 'inBackground'
         }, {
             tagName: 'rect',


### PR DESCRIPTION
Styling fix for the node which suffered a regression during the 1.0 released. Nodes should now be sized correctly when they contain an empty attributes list and input/output nodes also display a border below their header.

![image](https://user-images.githubusercontent.com/1721533/133996121-6d0f83c4-8e93-45c5-b8be-0480c4e3e5ba.png)
