### PR TITLE
Remove the pc-icon font

### DIFF
--- a/src/style-fonts.scss
+++ b/src/style-fonts.scss
@@ -1,16 +1,3 @@
-@font-face {
-    font-family: 'pc-icon';
-    src: url('https://playcanvas.com/static-assets/fonts/PlayIcons-Regular.eot');
-    src: url('https://playcanvas.com/static-assets/fonts/PlayIcons-Regular.eot?#iefix') format('embedded-opentype'),
-         url('https://playcanvas.com/static-assets/fonts/PlayIcons-Regular.woff2') format('woff2'),
-         url('https://playcanvas.com/static-assets/fonts/PlayIcons-Regular.woff') format('woff'),
-         url('https://playcanvas.com/static-assets/fonts/PlayIcons-Regular.ttf') format('truetype'),
-         url('https://playcanvas.com/static-assets/fonts/PlayIcons-Regular.svg') format('svg');
-
-    font-weight: normal;
-    font-style: normal;
-}
-
 .font-regular, .font-bold, .font-thin, .font-light {
     font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
This is already imported via the PCUI library. It's not necessary to include it directly in this package.