### PR TITLE
Node attributes update

### DIFF
--- a/.storybook/stories/basic/node-attributes.jsx
+++ b/.storybook/stories/basic/node-attributes.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { GRAPH_ACTIONS } from '../../../src/constants';
+import Component from '../../base-component';
+
+var name = 'Node Attributes Graph';
+var config = {
+    title: `Basic/${name}`
+};
+
+export default {
+    title: config.title,
+    component: Component,
+    parameters: {
+        docs: {}
+    }
+};
+
+const GRAPH_ENUM = {
+    NODE: {
+        HELLO: 0,
+        WORLD: 1,
+    },
+    EDGE: {
+        HELLO_TO_WORLD: 0,
+    }
+};
+
+const GRAPH_SCHEMA = {
+    nodes: {
+        [GRAPH_ENUM.NODE.HELLO]: {
+            name: 'Hello',
+            headerTextFormatter: (attributes) => `Hello ${attributes.foo}`,
+            outPorts: [
+                {
+                    name: 'output',
+                    type: GRAPH_ENUM.EDGE.HELLO_TO_WORLD,
+                    textFormatter: (attributes) => `output (${attributes.foo})`
+                }
+            ],
+            attributes: [
+                {
+                    name: 'foo',
+                    type: 'TEXT_INPUT'
+                }
+            ]
+        },
+        [GRAPH_ENUM.NODE.WORLD]: {
+            name: 'World',
+            inPorts: [
+                {
+                    name: 'input',
+                    type: GRAPH_ENUM.EDGE.HELLO_TO_WORLD,
+                    textFormatter: (attributes) => `input (${attributes.foo})`
+                }
+            ],
+            attributes: [
+                {
+                    name: 'foo',
+                    type: 'TEXT_INPUT',
+                    hidden: true
+                }
+            ]
+        }
+    },
+    edges: {
+        [GRAPH_ENUM.EDGE.HELLO_TO_WORLD]: {
+            from: GRAPH_ENUM.NODE.HELLO,
+            to: GRAPH_ENUM.NODE.WORLD,
+        }
+    }
+};
+
+var GRAPH_DATA = {
+    nodes: {
+        1234: {
+            id: 1234,
+            nodeType: GRAPH_ENUM.NODE.HELLO,
+            name: 'Hello',
+            posX: 200,
+            posY: 200,
+            attributes: {
+                foo: 'bar'
+            }
+        },
+        1235: {
+            id: 1235,
+            nodeType: GRAPH_ENUM.NODE.WORLD,
+            name: 'World',
+            posX: 500,
+            posY: 200,
+            attributes: {
+                foo: 'bar'
+            }
+        },
+    },
+    edges: {
+        '1234,0-1235,0': {
+            edgeType: GRAPH_ENUM.EDGE.HELLO_TO_WORLD,
+            from: 1234,
+            to: 1235,
+            inPort: 0,
+            outPort: 0,
+        }
+    }
+};
+
+export const NodeAttributesGraphExample = (args) => { 
+    return <Component schema={GRAPH_SCHEMA} options={{
+        initialData: GRAPH_DATA,
+        passiveUIEvents: false,
+        includeFonts: true,
+        defaultStyles: {
+            edge: {
+                connectionStyle: 'smoothInOut'
+            },
+            background: {
+                color: '#20292B',
+                gridSize: 10
+            }
+        }
+    }} />;
+};
+
+document.querySelector('#root').setAttribute('style', 'position: fixed; width: 100%; height: 100%');
+document.body.setAttribute('style', 'margin: 0px; padding: 0px;');
+
+setTimeout(() => {
+    const graph = document.querySelector('.pcui-graph').ui;
+    graph.on(GRAPH_ACTIONS.UPDATE_NODE_ATTRIBUTE, (data) => {
+        graph.updateNodeAttribute(1235, data.attribute, data.node.attributes[data.attribute]);
+    });
+}, 500);

--- a/src/index.js
+++ b/src/index.js
@@ -370,7 +370,7 @@ class Graph extends Element {
             node.attributes[attributeKey] = value;
         }
         if (JSON.stringify(node.attributes[attributeKey]) === JSON.stringify(prevAttributeValue)) return;
-        this.updateNodeAttribute(nodeId, attribute.name, prevAttributeValue);
+        this.updateNodeAttribute(nodeId, attribute.name, value);
         this._dispatchEvent(
             GRAPH_ACTIONS.UPDATE_NODE_ATTRIBUTE,
             {
@@ -634,7 +634,7 @@ class Graph extends Element {
             this.updateNodePosition(nodeId, { x: node.posX, y: node.posY });
         });
         this.on(GRAPH_ACTIONS.UPDATE_NODE_ATTRIBUTE, ({ node }) => {
-            this._graphData.set(`data.nodes.${nodeId}`, node);
+            this._graphData.set(`data.nodes.${node.id}`, node);
         });
         this.on(GRAPH_ACTIONS.ADD_EDGE, ({ edge, edgeId }) => {
             if (Number.isFinite(edge.inPort)) {


### PR DESCRIPTION
- Supports hiding node attributes from the node's UI
- Supports text formatters for node headers and port labels
- Adds a node attributes story which highlights these features

![image](https://user-images.githubusercontent.com/1721533/140559296-a7e703b3-e4d7-4a3d-b7bf-d10c4459271e.png)

This story shows two nodes. The hello node contains a foo attribute which is editable via a text input. The hello node's header and output port uses text formatters to display the current foo attribute value. The world node also contains a foo attribute but this is set to hidden. The world node's input port uses a text formatter which displays it's hidden foo attribute value. The story graph then contains an event handler which set's the world node's foo attribute when the hello node's foo attribute is edited.

Fixes #3
Fixes #4 