### PR TITLE
Node attribute input creation fix

### DIFF
--- a/src/graph-view-node.js
+++ b/src/graph-view-node.js
@@ -265,7 +265,7 @@ class GraphViewNode {
                 let input;
                 let nodeValue;
                 if (nodeData.attributes) {
-                    if (nodeData.attributes[attribute.name]) {
+                    if (nodeData.attributes[attribute.name] !== undefined) {
                         nodeValue = nodeData.attributes[attribute.name];
                     } else {
                         Object.keys(nodeData.attributes).forEach((k) => {


### PR DESCRIPTION
Fixes an issue where a node attribute's input field will be incorrectly initialised if a node attribute's initial value is set to a falsy value.