### PR TITLE
Expose the adjustVertices config option

### DIFF
--- a/.storybook/stories/advanced/directed-graph.stories.jsx
+++ b/.storybook/stories/advanced/directed-graph.stories.jsx
@@ -106,6 +106,11 @@ var GRAPH_DATA = {
             from: 1235,
             to: 1236
         },
+        '1236-1235': {
+            edgeType: GRAPH_ENUM.EDGE.EDGE,
+            from: 1236,
+            to: 1235
+        }
     }
 };
 
@@ -129,6 +134,7 @@ export const DirectedGraphExample = (args) => {
         passiveUIEvents: false,
         includeFonts: true,
         incrementNodeNames: true,
+        adjustVertices: true,
         defaultStyles: {
             background: {
                 color: '#20292B',

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,7 @@ export var DEFAULT_CONFIG = {
     edgeHoverEffect: true,
     includeFonts: true,
     useGlobalPCUI: false,
+    adjustVertices: false,
     defaultStyles: {
         initialScale: 1,
         initialPosition: {

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ class Graph extends Element {
      * @param {boolean} options.edgeHoverEffect - Whether the graph should show an edge highlight effect when the mouse is hovering over edges. Optional. Defaults to true.
      * @param {boolean} options.includeFonts - If true the graph will include a default font style. Defaults to true.
      * @param {object} options.defaultStyles - Used to override the graph's default styling. Check ./constants.js for a full list of style properties.
+     * @param {object} options.adjustVertices - If true, multiple edges conntected between two nodes will be spaced apart.
      */
     constructor(schema, options = {}) {
         super(options.dom ? options.dom : document.createElement('div'), {});
@@ -42,7 +43,8 @@ class Graph extends Element {
             restrictTranslate: options.restrictTranslate,
             edgeHoverEffect: options.edgeHoverEffect,
             includeFonts: options.includeFonts,
-            useGlobalPCUI: options.useGlobalPCUI
+            useGlobalPCUI: options.useGlobalPCUI,
+            adjustVertices: options.adjustVertices
         };
         if (options.defaultStyles) {
             if (options.defaultStyles.background) {


### PR DESCRIPTION
The adjustVertices config option was not exposed in the graphs config object.
This PR also adds this option to the directed graph example as a test for this use case.
![image](https://user-images.githubusercontent.com/1721533/142644227-da45c576-a8af-4ab0-8902-8746afe89a04.png)
