### PR TITLE
Node attribute updates

### DIFF
--- a/.storybook/stories/basic/node-attribute-error.jsx
+++ b/.storybook/stories/basic/node-attribute-error.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { GRAPH_ACTIONS } from '../../../src/constants';
+import Component from '../../base-component';
+
+var name = 'Node Attribute Error Graph';
+var config = {
+    title: `Basic/${name}`
+};
+
+export default {
+    title: config.title,
+    component: Component,
+    parameters: {
+        docs: {}
+    }
+};
+
+const GRAPH_ENUM = {
+    NODE: {
+        HELLO_WORLD: 0,
+    }
+};
+
+const GRAPH_SCHEMA = {
+    nodes: {
+        [GRAPH_ENUM.NODE.HELLO_WORLD]: {
+            name: 'Alphabet Only',
+            attributes: [
+                {
+                    name: 'text',
+                    type: 'TEXT_INPUT'
+                }
+            ]
+        }
+    }
+};
+
+var GRAPH_DATA = {
+    nodes: {
+        1234: {
+            id: 1234,
+            nodeType: GRAPH_ENUM.NODE.HELLO_WORLD,
+            name: 'Alphabet Only',
+            posX: 200,
+            posY: 200,
+            attributes: {
+                text: 'abcdef'
+            }
+        }
+    },
+    edges: {}
+};
+
+export const NodeAttributeErrorGraphExample = (args) => { 
+    return <Component schema={GRAPH_SCHEMA} options={{
+        initialData: GRAPH_DATA,
+        passiveUIEvents: false,
+        includeFonts: true,
+        defaultStyles: {
+            edge: {
+                connectionStyle: 'smoothInOut'
+            },
+            background: {
+                color: '#20292B',
+                gridSize: 10
+            }
+        }
+    }} />;
+};
+
+document.querySelector('#root').setAttribute('style', 'position: fixed; width: 100%; height: 100%');
+document.body.setAttribute('style', 'margin: 0px; padding: 0px;');
+
+setTimeout(() => {
+    const graph = document.querySelector('.pcui-graph').ui;
+    graph.on(GRAPH_ACTIONS.UPDATE_NODE_ATTRIBUTE, (data) => {
+        if (data.node.attributes[data.attribute].match('^[A-Za-z]*$')) {
+            graph.updateNodeAttribute(1234, data.attribute, data.node.attributes[data.attribute]);
+            graph.setNodeAttributeErrorState(1234, data.attribute, false);
+        } else {
+            graph.setNodeAttributeErrorState(1234, data.attribute, true);
+        }
+    });
+}, 500);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui-graph",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/pcui-graph",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://github.com/playcanvas/pcui-graph",
   "description": "",

--- a/src/graph-view-node.js
+++ b/src/graph-view-node.js
@@ -40,8 +40,9 @@ class GraphViewNode {
         var rectSize = { x: this.getSchemaValue('baseWidth'), y: rectHeight + portHeight + attributeHeight };
 
         var labelName;
-        if (nodeSchema.headerTextFormatter) {
-            labelName = nodeSchema.headerTextFormatter(nodeData.attributes);
+        var formattedText = nodeSchema.headerTextFormatter && nodeSchema.headerTextFormatter(nodeData.attributes, nodeData.id);
+        if (typeof formattedText === 'string') {
+            labelName = nodeSchema.headerTextFormatter(nodeData.attributes, nodeData.id);
         } else if (nodeSchema.outPorts || nodeSchema.inPorts) {
             labelName = nodeData.attributes && nodeData.attributes.name ? `${nodeData.attributes.name} (${nodeSchema.name})` : nodeSchema.name;
         } else {
@@ -392,7 +393,10 @@ class GraphViewNode {
 
     updateFormattedTextFields() {
         if (this.nodeSchema.headerTextFormatter) {
-            this.model.attr('label/text', this.nodeSchema.headerTextFormatter(this.nodeData.attributes));
+            const formattedText = this.nodeSchema.headerTextFormatter(this.nodeData.attributes, this.nodeData.id);
+            if (typeof formattedText === 'string') {
+                this.model.attr('label/text', formattedText);
+            }
         }
         if (this.nodeSchema.outPorts) {
             this.nodeSchema.outPorts.forEach((port, i) => {
@@ -424,6 +428,13 @@ class GraphViewNode {
             attributeElement.ui.suspendEvents = false;
         }
         this.updateFormattedTextFields();
+    }
+
+    setAttributeErrorState(attribute, value) {
+        const attributeElement = document.querySelector(`#nodediv_${this.model.id}`).querySelector(`#input_${attribute}`);
+        if (attributeElement) {
+            attributeElement.ui.error = value;
+        }
     }
 
     updateNodeType(nodeType) {

--- a/src/graph-view.js
+++ b/src/graph-view.js
@@ -222,6 +222,10 @@ class GraphView extends JointGraph {
         this.getNode(id).updateAttribute(attribute, value);
     }
 
+    setNodeAttributeErrorState(id, attribute, value) {
+        this.getNode(id).setAttributeErrorState(attribute, value);
+    }
+
     updateNodePosition(id, pos) {
         this.getNode(id).updatePosition(pos);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -467,6 +467,19 @@ class Graph extends Element {
 
     /**
      *
+     * Set the error state of a node attribute
+     *
+     * @param {number} nodeId - The node to update
+     * @param {string} attributeName - The name of the attribute to update
+     * @param {boolean} value - Whether the attribute should be set in the error state
+     */
+    setNodeAttributeErrorState(nodeId, attributeName, value) {
+        if (!this._graphData.get(`data.nodes.${nodeId}`)) return;
+        this.view.setNodeAttributeErrorState(nodeId, attributeName, value);
+    }
+
+    /**
+     *
      * Update the type of a node
      *
      * @param {number} nodeId - The node to update


### PR DESCRIPTION
- Adds a setNodeAttributeErrorState method to the graph which allows users to toggle the error state of a nodes attribute.
- The headerTextFormatter schema function is now supplied a node id along with it's attributes and will only set the header text if the returned value is a string.
- Bumps the PCUI Graph version