### PR TITLE
Fix shifting node while clicking on them.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020 PlayCanvas Ltd.
+Copyright (c) 2011-2022 PlayCanvas Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/graph-view-node.js
+++ b/src/graph-view-node.js
@@ -454,7 +454,7 @@ class GraphViewNode {
         switch (event) {
             case 'updatePosition': {
                 nodeView.on('element:pointerup', () => {
-                    var newPos = this._graphView.getWindowToGraphPosition(nodeView.el.getBoundingClientRect());
+                    var newPos = this._graphView.getWindowToGraphPosition(nodeView.getBBox());
                     callback(this.nodeData.id, newPos);
                 });
                 break;


### PR DESCRIPTION
Fix an issue that was causing nodes to shift while clicking on them on Firefox.

Reason: probably, we should use [getBBox](https://resources.jointjs.com/docs/jointjs/v3.6/joint.html#dia.Element.prototype.getBBox) because it returns "the dimensions of the element's model, not the dimensions of the element's view".
