### PR TITLE
Fix the getWindowToGraphPosition function

### DIFF
--- a/src/graph-view-node.js
+++ b/src/graph-view-node.js
@@ -455,7 +455,7 @@ class GraphViewNode {
         switch (event) {
             case 'updatePosition': {
                 nodeView.on('element:pointerup', () => {
-                    var newPos = this._graphView.getWindowToGraphPosition(nodeView.getBBox());
+                    var newPos = this._graphView.getWindowToGraphPosition(nodeView.getBBox(), false);
                     callback(this.nodeData.id, newPos);
                 });
                 break;

--- a/src/graph-view.js
+++ b/src/graph-view.js
@@ -157,13 +157,17 @@ class GraphView extends JointGraph {
         }
     }
 
-    getWindowToGraphPosition(pos) {
+    getWindowToGraphPosition(pos, usePaperPosition = true) {
         const scale = this._paper.scale().sx;
         const translate = this._paper.translate();
-        const boundingClientRect = this._paper.el.getBoundingClientRect();
+        if (usePaperPosition) {
+            const paperPosition = this._paper.el.getBoundingClientRect();
+            pos.x -= paperPosition.x;
+            pos.y -= paperPosition.y;
+        }
         return new Vec2(
-            (-translate.tx / scale) + ((pos.x - boundingClientRect.x) / scale),
-            (-translate.ty / scale) + ((pos.y - boundingClientRect.y) / scale)
+            (-translate.tx / scale) + (pos.x / scale),
+            (-translate.ty / scale) + (pos.y / scale)
         );
     }
 


### PR DESCRIPTION
The getWindowToGraphPosition function should support transforming positions which need to take into account the position of the graph in the window. This is used when transforming values which come from MouseEvents etc.

If the usePaperPosition parameter is set to false, it will assume that the position passed into the function was relative to a graph positioned at the origin.