### PR TITLE
updateNodeType fix

### DIFF
--- a/src/graph-view-node.js
+++ b/src/graph-view-node.js
@@ -442,7 +442,6 @@ class GraphViewNode {
 
     updateNodeType(nodeType) {
         this._paper.findViewByModel(this.model).el.removeEventListener('contextmenu', this._contextMenu._contextMenuEvent);
-        this._paper.el.removeChild(this._contextMenuElement);
         this.addContextMenu(this._graphSchema.nodes[nodeType].contextMenuItems);
     }
 


### PR DESCRIPTION
Since removing the context menu component and replacing it with the menu component, the context menu element is no longer stored in the graph view node. When updating a node's type, it's no longer necessary to remove the previous context menu from the graph's paper.