### PR TITLE
feat: add public selectedItem getter to Graph

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,20 @@ class Graph extends Element {
     }
 
     /**
+     * The currently selected item in the graph, or null if nothing is selected.
+     *
+     * @type {{ type: ('NODE'|'EDGE'), id: string|number, edgeId: string|number|undefined }|null}
+     */
+    get selectedItem() {
+        if (!this._selectedItem) return null;
+        return {
+            type: this._selectedItem.type,
+            id: this._selectedItem.id,
+            edgeId: this._selectedItem.edgeId
+        };
+    }
+
+    /**
      * Destroy the graph. Clears the graph from the DOM and removes all event listeners associated
      * with the graph.
      */


### PR DESCRIPTION
## Summary

- Adds a public `selectedItem` getter to the `Graph` class, exposing the currently selected item (or `null` if nothing is selected)
- This allows consumers (e.g. the PlayCanvas Editor's AnimStateGraph view) to check selection state without accessing the private `_selectedItem` field

## Test plan

- [x] Verify `graph.selectedItem` returns the selected node/edge after calling `selectNode`/`selectEdge`
- [x] Verify `graph.selectedItem` returns `null` after calling `deselectItem`
