### PR TITLE
fix: include edgeId in SELECT_EDGE event payload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -285,7 +285,7 @@ class Graph extends Element {
     createEdge(edge, edgeId) {
         const edgeSchema = this._graphSchema.edges[edge.edgeType];
         this.view.addEdge(edge, edgeSchema, (edge) => {
-            this._dispatchEvent(GRAPH_ACTIONS.SELECT_EDGE, { edge, prevItem: this._selectedItem });
+            this._dispatchEvent(GRAPH_ACTIONS.SELECT_EDGE, { edge, edgeId, prevItem: this._selectedItem });
         });
         if (edgeSchema.contextMenuItems) {
             const contextMenuItems = deepCopyFunction(edgeSchema.contextMenuItems).map((item) => {


### PR DESCRIPTION
## Summary

- Includes `edgeId` in the `SELECT_EDGE` event payload dispatched from `createEdge`
- Previously, clicking an edge fired `{ edge, prevItem }` without the `edgeId`, so consumers using `passiveUIEvents` could not identify which specific edge was selected
- This fixes keyboard-driven edge deletion in the PlayCanvas Editor's AnimStateGraph view

## Test plan

- [x] Click an edge in a graph using `passiveUIEvents: true`
- [x] Verify the `SELECT_EDGE` event payload includes `edgeId`
