### PR TITLE
fix: context menu null guards and handler cleanup

### DIFF
--- a/src/graph-view-node.ts
+++ b/src/graph-view-node.ts
@@ -41,6 +41,8 @@ class GraphViewNode {
 
     _contextMenu: Menu | null;
 
+    _contextMenuHandler: ((e: MouseEvent) => void) | null;
+
     _suppressChangeTargetEvent: boolean;
 
     _hasLinked: boolean;
@@ -54,6 +56,7 @@ class GraphViewNode {
         this.nodeData = nodeData;
         this.nodeSchema = nodeSchema;
         this.state = GraphViewNode.STATES.DEFAULT;
+        this._contextMenuHandler = null;
         this._suppressChangeTargetEvent = false;
         this._hasLinked = false;
 
@@ -449,11 +452,12 @@ class GraphViewNode {
         });
         this._paper.el.appendChild(this._contextMenu.dom);
         const nodeElement = this._paper.findViewByModel(this.model).el;
-        nodeElement.addEventListener('contextmenu', (e: MouseEvent) => {
+        this._contextMenuHandler = (e: MouseEvent) => {
             e.preventDefault();
             this._contextMenu.position(e.clientX, e.clientY);
             this._contextMenu.hidden = false;
-        });
+        };
+        nodeElement.addEventListener('contextmenu', this._contextMenuHandler);
     }
 
     mapVectorToArray(v: any): number[] {
@@ -512,7 +516,9 @@ class GraphViewNode {
     }
 
     updateNodeType(nodeType: string | number): void {
-        this._paper.findViewByModel(this.model).el.removeEventListener('contextmenu', (this._contextMenu as any)._contextMenuEvent);
+        if (this._contextMenuHandler) {
+            this._paper.findViewByModel(this.model).el.removeEventListener('contextmenu', this._contextMenuHandler);
+        }
         this.addContextMenu(this._graphSchema.nodes[nodeType].contextMenuItems);
     }
 

--- a/src/graph-view.ts
+++ b/src/graph-view.ts
@@ -67,6 +67,7 @@ class GraphView extends JointGraph {
         });
         this._paper.on({
             'blank:contextmenu': (event: dia.Event) => {
+                if (!this._viewMenu) return;
                 this._viewMenu.position(event.clientX, event.clientY);
                 this._viewMenu.hidden = false;
             }


### PR DESCRIPTION
## Summary

- Guard `blank:contextmenu` handler in `GraphView` against uninitialized `_viewMenu` (e.g. in readOnly mode), preventing a runtime crash
- Fix `updateNodeType` in `GraphViewNode` to correctly remove the old contextmenu event listener before adding a new one — the previous code referenced `Menu._contextMenuEvent` (an unrelated PCUI internal), so `removeEventListener` was always a no-op and handlers accumulated on each call

## Test plan

- [x] Open the Anim State Graph editor in the PlayCanvas Editor
- [x] Change a node's type and verify the context menu still works correctly (only one handler fires)
- [x] Verify right-clicking on the blank canvas in readOnly mode does not throw
