### PR TITLE
fix: stabilize sibling edge offset ordering in adjustVertices

### DIFF
--- a/src/joint-graph.ts
+++ b/src/joint-graph.ts
@@ -239,6 +239,13 @@ class JointGraph {
             return ((siblingSourceId === sourceId) && (siblingTargetId === targetId)) ||
                 ((siblingSourceId === targetId) && (siblingTargetId === sourceId));
         });
+        // Sort by model ID so offset assignment is stable across calls
+        // (internal cell order can change due to toBack/toFront operations)
+        siblings.sort((a: dia.Link, b: dia.Link) => {
+            if (a.id < b.id) return -1;
+            if (a.id > b.id) return 1;
+            return 0;
+        });
         const numSiblings = siblings.length;
         switch (numSiblings) {
             case 0: {


### PR DESCRIPTION
## Summary

- Fixes transition arrows visually swapping position on first click (#107)
- Sorts sibling edges by model ID in `adjustVertices` before assigning perpendicular offsets, ensuring stable positioning across calls regardless of internal JointJS cell reordering from `toBack()`/`toFront()` operations

## Test plan

- [x] Open the [Advanced Directed Graph storybook example](https://playcanvas.github.io/pcui-graph/storybook/?path=/story/advanced-directed-graph--directed-graph-example)
- [x] Click on a transition arrow (e.g. B -> C or C -> B)
- [x] Verify arrows do not swap positions
