### PR TITLE
fix: prevent node position shift on click

### DIFF
--- a/src/graph-view-node.ts
+++ b/src/graph-view-node.ts
@@ -531,8 +531,8 @@ class GraphViewNode {
         switch (event) {
             case 'updatePosition': {
                 nodeView.on('element:pointerup', () => {
-                    const newPos = this._graphView.getWindowToGraphPosition(nodeView.getBBox(), false);
-                    callback(this.nodeData.id, newPos);
+                    const pos = this.model.position();
+                    callback(this.nodeData.id, { x: pos.x, y: pos.y });
                 });
                 break;
             }


### PR DESCRIPTION
## Summary

- Fix node position shifting left on click for nodes with ports (Fixes #117)
- Replace `nodeView.getBBox()` with `model.position()` to read node position after pointer-up

## Details

`nodeView.getBBox()` returns the SVG bounding box of the entire rendered element group, which includes port circles. Input port circles extend a few pixels to the left of the node body origin (`cx: 1`, `r: 5`), making `bbox.x` smaller than the actual model position. This incorrect position was written back on every click, causing a progressive leftward shift.

`model.position()` returns the authoritative position in graph coordinates, unaffected by port geometry.

## Test plan

- [x] Open the [Visual Programming Graph](https://playcanvas.github.io/pcui-graph/storybook/?path=/story/advanced-visual-programming-graph--visual-programming-graph-example) story in Storybook
- [x] Click (no drag) on nodes with ports (Texture, Multiply, Sine, Fragment Output) — they should stay in place
- [x] Click on nodes without ports (uvCoords, maxAlpha, time) — they should still stay in place
- [x] Drag nodes and verify positions update correctly after release
