### PR TITLE
refactor: initialize class fields at point of declaration

### DIFF
--- a/src/graph-view-edge.ts
+++ b/src/graph-view-edge.ts
@@ -35,11 +35,11 @@ class GraphViewEdge {
 
     _edgeSchema: any;
 
-    state: number;
+    state = GraphViewEdge.STATES.DEFAULT;
 
     model: shapes.standard.Link;
 
-    _contextMenu: Menu | null;
+    _contextMenu: Menu | null = null;
 
     constructor(graphView: GraphView, paper: dia.Paper, graph: dia.Graph, graphSchema: any, edgeData: any, edgeSchema: any, onEdgeSelected: (edgeData: any) => void) {
         this._graphView = graphView;
@@ -49,8 +49,6 @@ class GraphViewEdge {
         this._graphSchema = graphSchema;
         this.edgeData = edgeData;
         this._edgeSchema = edgeSchema;
-        this.state = GraphViewEdge.STATES.DEFAULT;
-        this._contextMenu = null;
 
         const link = GraphViewEdge.createLink(this._config.defaultStyles, edgeSchema, edgeData);
         const sourceNode = this._graphView.getNode(edgeData.from);

--- a/src/graph-view-node.ts
+++ b/src/graph-view-node.ts
@@ -35,17 +35,17 @@ class GraphViewNode {
 
     nodeSchema: any;
 
-    state: number;
+    state = GraphViewNode.STATES.DEFAULT;
 
     model: dia.Element;
 
     _contextMenu: Menu | null;
 
-    _contextMenuHandler: ((e: MouseEvent) => void) | null;
+    _contextMenuHandler: ((e: MouseEvent) => void) | null = null;
 
-    _suppressChangeTargetEvent: boolean;
+    _suppressChangeTargetEvent = false;
 
-    _hasLinked: boolean;
+    _hasLinked = false;
 
     constructor(graphView: GraphView, paper: dia.Paper, graph: dia.Graph, graphSchema: any, nodeData: any, nodeSchema: any, onCreateEdge: (edgeId: string, edge: any) => void, onNodeSelected: (nodeData: any) => void) {
         this._graphView = graphView;
@@ -55,10 +55,6 @@ class GraphViewNode {
         this._graphSchema = graphSchema;
         this.nodeData = nodeData;
         this.nodeSchema = nodeSchema;
-        this.state = GraphViewNode.STATES.DEFAULT;
-        this._contextMenuHandler = null;
-        this._suppressChangeTargetEvent = false;
-        this._hasLinked = false;
 
         const rectHeight = this.getSchemaValue('baseHeight');
         let portHeight = 0;

--- a/src/graph-view.ts
+++ b/src/graph-view.ts
@@ -19,15 +19,15 @@ class GraphView extends JointGraph {
 
     _graphData: any;
 
-    _nodes: Record<string, GraphViewNode>;
+    _nodes: Record<string, GraphViewNode> = {};
 
-    _edges: Record<string, GraphViewEdge>;
+    _edges: Record<string, GraphViewEdge> = {};
 
-    _cells: dia.Cell[];
+    _cells: dia.Cell[] = [];
 
-    _cellMountedFunctions: (() => void)[];
+    _cellMountedFunctions: (() => void)[] = [];
 
-    _batchingCells: boolean;
+    _batchingCells = false;
 
     _viewMenu: Menu;
 
@@ -40,13 +40,6 @@ class GraphView extends JointGraph {
         this._graphData = graphData;
 
         this._config = config;
-
-        this._nodes = {};
-        this._edges = {};
-
-        this._cells = [];
-        this._cellMountedFunctions = [];
-        this._batchingCells = false;
 
         const htmlShapes = shapes as Record<string, any>;
         htmlShapes.html = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,13 +50,13 @@ class Graph extends Element {
 
     _contextMenuItems: any[];
 
-    _suppressGraphDataEvents: boolean;
+    _suppressGraphDataEvents = false;
 
     _config: any;
 
-    _selectedItem: SelectedItem | null;
+    _selectedItem: SelectedItem | null = null;
 
-    suppressNodeSelect: boolean;
+    suppressNodeSelect = false;
 
     view: GraphView;
 
@@ -92,9 +92,6 @@ class Graph extends Element {
         this._graphSchema = schema;
         this._graphData = new Observer({ data: options.initialData ? options.initialData : {} });
         this._contextMenuItems = options.contextMenuItems || [];
-        this._suppressGraphDataEvents = false;
-        this._selectedItem = null;
-        this.suppressNodeSelect = false;
 
         this._config = {
             ...DEFAULT_CONFIG,

--- a/src/joint-graph.ts
+++ b/src/joint-graph.ts
@@ -40,17 +40,17 @@ class JointGraph {
 
     _paper: dia.Paper;
 
-    _panPaper: boolean;
+    _panPaper = false;
 
-    _translate: Vec2;
+    _translate = new Vec2();
 
-    _totalTranslate: Vec2;
+    _totalTranslate = new Vec2();
 
-    _pan: Vec2;
+    _pan = new Vec2();
 
-    _mousePos: Vec2;
+    _mousePos = new Vec2();
 
-    ignoreAdjustVertices: boolean;
+    ignoreAdjustVertices = false;
 
     constructor(dom: HTMLElement, config: any = {}) {
 
@@ -131,12 +131,6 @@ class JointGraph {
         });
         graphResizeObserver.observe(dom);
 
-        this._panPaper = false;
-        this._translate = new Vec2();
-        this._totalTranslate = new Vec2();
-        this._pan = new Vec2();
-        this._mousePos = new Vec2();
-        this.ignoreAdjustVertices = false;
         this._paper.on('blank:pointerdown', (e: dia.Event) => {
             this._panPaper = true;
             this._mousePos = new Vec2(e.offsetX, e.offsetY);


### PR DESCRIPTION
## Summary

- Move simple default field values (`false`, `null`, `new Vec2()`, `{}`, `[]`) from constructors to field declarations across all pcui-graph classes
- Affects `JointGraph`, `GraphView`, `GraphViewNode`, `GraphViewEdge`, and `Graph`
- No behavioral changes; purely a code style improvement

## Test plan

- [x] `npm run lint` passes with no errors
- [x] Verify the graph editor loads and functions correctly (node creation, edge connection, selection, panning, zooming)
