### PR TITLE
fix: clear inline 0px dimensions when element is not yet in DOM

### DIFF
--- a/src/joint-graph.ts
+++ b/src/joint-graph.ts
@@ -100,8 +100,12 @@ class JointGraph {
         // is not yet in the DOM, those values are 0px which overrides the CSS
         // 100% sizing and prevents the ResizeObserver from ever firing. Clear
         // the inline dimensions so CSS can take over once the element is inserted.
-        if (!dom.offsetWidth && !dom.offsetHeight) {
+        // Clear width/height independently, but only if JointJS has set them to 0px
+        // inline to avoid wiping intentional inline sizing.
+        if (!dom.offsetWidth && dom.style.width === '0px') {
             dom.style.width = '';
+        }
+        if (!dom.offsetHeight && dom.style.height === '0px') {
             dom.style.height = '';
         }
 

--- a/src/joint-graph.ts
+++ b/src/joint-graph.ts
@@ -96,6 +96,15 @@ class JointGraph {
             }
         });
 
+        // JointJS Paper sets inline width/height on the element. When the element
+        // is not yet in the DOM, those values are 0px which overrides the CSS
+        // 100% sizing and prevents the ResizeObserver from ever firing. Clear
+        // the inline dimensions so CSS can take over once the element is inserted.
+        if (!dom.offsetWidth && !dom.offsetHeight) {
+            dom.style.width = '';
+            dom.style.height = '';
+        }
+
         const graphResizeObserver = new ResizeObserver(() => {
             this._resizeGraph(dom);
         });


### PR DESCRIPTION
## Summary

- Fixes the graph rendering at 0x0 when the `Graph` is constructed before its DOM element is inserted into the document (the standalone usage pattern documented in the README)

## Details

When a `Graph` is created without the `dom` option, JointJS Paper initializes with `width: dom.offsetWidth` and `height: dom.offsetHeight`, which are both 0 since the element isn't in the DOM yet. JointJS then sets inline `style="width: 0px; height: 0px"` on the element, permanently overriding the CSS `width: 100%; height: 100%`. The existing `ResizeObserver` never fires because the element's size never changes from 0x0.

The fix clears the inline width/height when they are zero after Paper construction, allowing CSS to take over and the `ResizeObserver` to fire once the element is inserted into the DOM.

This does not affect the `{ dom: existingElement }` usage pattern (e.g. in the PlayCanvas Editor) since those elements are already in the DOM with non-zero dimensions at construction time.

Fixes #17