### PR TITLE
chore: remove stale react peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,7 @@
       },
       "peerDependencies": {
         "@playcanvas/observer": "^1.0.0",
-        "@playcanvas/pcui": "^6.0.0",
-        "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0"
+        "@playcanvas/pcui": "^6.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -10782,6 +10780,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10836,6 +10835,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -11418,6 +11418,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "nodes",
     "pcui",
     "playcanvas",
-    "react",
     "sass",
     "typescript",
     "ui"
@@ -116,9 +115,7 @@
   },
   "peerDependencies": {
     "@playcanvas/observer": "^1.0.0",
-    "@playcanvas/pcui": "^6.0.0",
-    "react": "^18.2.0 || ^19.0.0",
-    "react-dom": "^18.2.0 || ^19.0.0"
+    "@playcanvas/pcui": "^6.0.0"
   },
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
## Summary

- Remove stale `react` and `react-dom` peer dependencies (there are zero React imports in the source)
- Remove `"react"` from package keywords

## Test plan

- Verify `npm install` succeeds without React installed
- Verify `npm run build` completes successfully
