### PR TITLE
chore: prepare tsconfig for TypeScript 6 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "compilerOptions": {
         "noImplicitAny": true,
+        "strictNullChecks": false,
+        "rootDir": "./src",
         "target": "es2020",
         "module": "esnext",
         "jsx": "react",
@@ -12,7 +14,7 @@
         ],
         "esModuleInterop": true,
         "sourceMap": true,
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "skipLibCheck": true,
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

Prepares `tsconfig.json` so the build passes under TypeScript 6.x, unblocking the dependency bump in #144.

The CI failure on #144 is:

```
TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0.
```

After fixing that, two further TS 6 default-tightenings surface (`TS5011` rootDir, and new strict-null-check errors). This PR addresses all three with the smallest surgical change.

## Changes

- `moduleResolution`: `"node"` → `"bundler"`. The deprecated `node` (alias of `node10`) is a hard error in TS 6 and goes away in TS 7. `bundler` matches the Rollup-based build, pairs with the existing `"module": "esnext"`, and requires no source changes — all relative imports in `src/` are already extension-less.
- `rootDir`: set explicitly to `"./src"`. TS 6 no longer infers it from the input set (TS5011).
- `strictNullChecks`: explicitly set to `false`. TS 6 flipped the default and the codebase was authored without strict-null semantics; making this explicit preserves prior behavior and keeps the dependency bump scoped.

## Verification

Locally with `typescript@6.0.3`:

- `npm run build` — green (UMD + ESM + styles + `.d.ts` emit)
- `npm run lint` — green

Once this lands, Renovate will rebase #144 and CI should go green.
